### PR TITLE
Release V1.1.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.24'
 
     - name: Test
       run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,14 +12,21 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    name: Tests & Benchmarks
+
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "windows-latest"]
+        go: ["1.24.x", "1.23.x", "1.22.x", "1.21.x", "1.20.x", "1.19.x", "1.18.x", "1.17.x", "1.16.x", "1.15.x", "1.14.x", "1.13.x"]
+
     steps:
     - uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.24'
+        go-version: ${{ matrix.go }}
 
     - name: Test
       run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,28 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.20'
+
+    - name: Test
+      run: go test -v ./...
+
+    - name: Benchmarks
+      run: go test -bench=. ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
-## v1.0.0 (2025-07-13)
+## v1.1.0 (2025-07-14)
+- Fix import path in code snippet example in `README.md`
+- Downgrade minimal Go version to `1.13`
+- Add GitHub Workflow CI with running tests and benchmarks
 
+## v1.0.0 (2025-07-13)
 - Implemented AES-256-GCM encryption/decryption (#1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
 ## v1.1.0 (2025-07-14)
-- Fix import path in code snippet example in `README.md`
-- Downgrade minimal Go version to `1.13`
-- Add GitHub Workflow CI with running tests and benchmarks
+- Fix import path in code snippet example in `README.md` [#2]
+- Downgrade minimal Go version to `1.13` [#3]
+- Add GitHub Workflow CI with running tests and benchmarks [#3]
 
 ## v1.0.0 (2025-07-13)
-- Implemented AES-256-GCM encryption/decryption (#1)
+- Implemented AES-256-GCM encryption/decryption [#1]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/dimastofff/aesgcm"
+	"github.com/dimastofff/aes-gcm-go"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/dimastofff/aes-gcm-go
 
-go 1.24
+go 1.13


### PR DESCRIPTION
## v1.1.0 (2025-07-14)
- Fix import path in code snippet example in `README.md` [#2]
- Downgrade minimal Go version to `1.13` [#3]
- Add GitHub Workflow CI with running tests and benchmarks [#3]